### PR TITLE
Change 2 tests that were not testing anything useful

### DIFF
--- a/test/clojurewerkz/buffy/util_test.clj
+++ b/test/clojurewerkz/buffy/util_test.clj
@@ -14,8 +14,8 @@
           false false false false
           false false false false
           false false false false
-          false false false false])
-      (bits-on-at [0 1 2] 4)))
+          false false false false]
+         (bits-on-at [0 1 2] 4))))
 
 (deftest bits-off-at-test
   (is (= [false false false true
@@ -25,8 +25,8 @@
           true true true true
           true true true true
           true true true true
-          true true true true])
-      (bits-on-at [0 1 2] 4)))
+          true true true true]
+         (bits-on-at [0 1 2] 4))))
 
 (deftest bits-on-indexes-test
   (is (= [0 1 2] (on-bits-indexes (bits-on-at [0 1 2] 4))))


### PR DESCRIPTION
They were of the form (is (= expr1) expr2), which always passes,
because (= expr1) is always true.  Changed them to what was probably
intended, which is (is (= expr1 expr2)).

The tests fail now, but I do not know enough about the function being
tested to know whether it is behaving as desired and the test should
be changed, or whether the test is correct and the function behavior
should change.

Found using a pre-release version of the Eastwood Clojure lint tool.
