### PR TITLE
Fix compose-buffer for wrapping ByteBuffer, fixes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ And for wrapped buffer (that wraps the given byte array,
 ```clj
 (def my-spec (spec :first-field (int32-type)
                    :second-field (string-type 10)))
-(compose-buffer my-spec :buffer (java.nio.ByteBuffer/allocate 14))
+(compose-buffer my-spec :orig-buffer (java.nio.ByteBuffer/allocate 14))
 ```
 
 ## Dynamic Frames

--- a/src/clojurewerkz/buffy/core.clj
+++ b/src/clojurewerkz/buffy/core.clj
@@ -4,7 +4,7 @@
             [clojurewerkz.buffy.frames :refer :all]
             [clojurewerkz.buffy.util :refer :all]
             [clojurewerkz.buffy.types.protocols :refer :all])
-  (:import [io.netty.buffer UnpooledByteBufAllocator ByteBufAllocator]))
+  (:import [io.netty.buffer Unpooled UnpooledByteBufAllocator ByteBufAllocator]))
 
 (def ^ByteBufAllocator allocator UnpooledByteBufAllocator/DEFAULT)
 
@@ -32,7 +32,7 @@
 (defn wrapped-buffer
   "Returns a buffer that wraps the given byte array, `j.nio.ByteBuffer` or netty `ByteBuf`"
   [orig-buffer]
-  (set-writer-index (.wrappedBuffer orig-buffer)))
+  (set-writer-index (Unpooled/wrappedBuffer orig-buffer)))
 
 (defprotocol Composable
   (decompose [this] [this buffer])

--- a/test/clojurewerkz/buffy/core_test.clj
+++ b/test/clojurewerkz/buffy/core_test.clj
@@ -313,7 +313,7 @@
 (deftest wrapped-buffer-test
   (let [s (spec :first-field (int32-type)
                 :second-field (string-type 10))
-        b (compose-buffer s :buffer (java.nio.ByteBuffer/allocate 14))]
+        b (compose-buffer s :orig-buffer (java.nio.ByteBuffer/allocate 14))]
     (set-field b :first-field 101)
     (is (= 101 (get-field b :first-field)))
 


### PR DESCRIPTION
Wraps a ByteBuffer, bytearray or ByteBuf properly.
