### PR TITLE
(fix) fixed formation and alignment in hexdump

### DIFF
--- a/src/clojurewerkz/buffy/util.clj
+++ b/src/clojurewerkz/buffy/util.clj
@@ -86,7 +86,7 @@
        (map to-ascii)
        j
        (partition-all 16)
-       (map #(format "%16s" (j %)))))
+       (map #(format "%-16s" (j %)))))
 
 (defn- format-hexdump
   "Formats hexsump"
@@ -104,7 +104,8 @@
                                              (= 0 (mod i 2))        " "
                                              :else                  ""))))
                    flatten
-                   j)))))
+                   j
+                   (format "%-48s"))))))
 
 (def header1   "            +--------------------------------------------------+\n")
 (def header2   "            | 0  1  2  3  4  5  6  7   8  9  a  b  c  d  e  f  |\n")


### PR DESCRIPTION
This patch fixes formation issue when bytes aren't zero-filled.

Before:

```
            +--------------------------------------------------+
            | 0  1  2  3  4  5  6  7   8  9  a  b  c  d  e  f  |
 +----------+--------------------------------------------------+------------------+
 | 00000000 | 08 00 10 01 1a 05 61 6b  34 37 38 22 04 61 6b 34 | ......ak478".ak4 | 
 | 00000010 | 37 4a 06 74 65 73 74 2f  30 6a 01 31 6a 01 32 6a | 7J.test/0j.1j.2j | 
 | 00000020 | 01 33 |               .3 | 
 +----------+--------------------------------------------------+------------------+
```

After:
```
            +--------------------------------------------------+
            | 0  1  2  3  4  5  6  7   8  9  a  b  c  d  e  f  |
 +----------+--------------------------------------------------+------------------+
 | 00000000 | 08 00 10 01 1a 05 61 6b  34 37 38 22 04 61 6b 34 | ......ak478".ak4 | 
 | 00000010 | 37 4a 06 74 65 73 74 2f  30 6a 01 31 6a 01 32 6a | 7J.test/0j.1j.2j | 
 | 00000020 | 01 33                                            | .3               | 
 +----------+--------------------------------------------------+------------------+
```