### PR TITLE
set-fields has been renamed to compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ You can also serialize and deserialize a complete buffer:
                   :third-field (boolean-type))
       buf  (compose-buffer spec)]
 
-  (set-fields buf {:first-field 101
-                   :second-field "string"
-                   :third-field true})
+  (compose buf {:first-field 101
+                :second-field "string"
+                :third-field true})
 
   (decompose buf)
   ;; => {:third-field true :second-field "string" :first-field 101}


### PR DESCRIPTION
The readme references `set-fields`. This function was renamed to `compose` in commit 449d62bbdff2cd3c786b9b2eb209058456b83c68. 

This PR simply updates the documentation in the README to use `compose` instead of `set-fields`.

Thanks for buffy!