### PR TITLE
wrapped-buffer: use underlying byte order

### DIFF
--- a/src/clojurewerkz/buffy/core.clj
+++ b/src/clojurewerkz/buffy/core.clj
@@ -59,7 +59,8 @@
 (defn wrapped-buffer
   "Returns a buffer that wraps the given byte array, `j.nio.ByteBuffer` or netty `ByteBuf`"
   [orig-buffer]
-  (rewind-until-end (Unpooled/wrappedBuffer orig-buffer)))
+  (rewind-until-end (.order (Unpooled/wrappedBuffer orig-buffer)
+                            (.order orig-buffer))))
 
 (defprotocol Composable
   (decompose [this] [this buffer])


### PR DESCRIPTION
When wrapping a byte buffer, use the underlying byte order.

Prior to this change, a wrapped byte buffer always had the `BIG_ENDIAN` byte order. This is inconvenient for protocols that are primarily little endian.