### PR TITLE
Dependencies, minor bugs, reflection warnings, and readability

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,18 +5,20 @@
   :license      {:name "Eclipse Public License"
                  :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure     "1.8.0"]
-                 [io.netty/netty-buffer   "4.0.51.Final"]
-                 [org.clojure/test.check  "0.6.2"]
-                 [criterium "0.4.4"]]
+  :dependencies [[org.clojure/clojure   "1.10.1"]
+                 [io.netty/netty-buffer "4.0.51.Final"]]
 
 ;  :jvm-opts     ["-noverify"
 ;                 "-javaagent:/Users/ifesdjeen/hackage/introspect/target/introspect-1.0.0-SNAPSHOT-standalone.jar=clojurewerkz.buffy.core"
 ;]
 
   :profiles     {:1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
-                 :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}
-                 :dev    {:resource-paths ["test/resources"]
+                 :1.8    {:dependencies [[org.clojure/clojure "1.8.0"]]}
+                 :1.9    {:dependencies [[org.clojure/clojure "1.9.0"]]}
+                 :master {:dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]]}
+                 :dev    {:dependencies [[org.clojure/test.check  "0.6.2"]
+                                         [criterium "0.4.4"]]
+                          :resource-paths ["test/resources"]
                           :plugins [[codox "0.8.10"]]
                           :codox {:sources ["src/clojure"]
                                   :output-dir "doc/api"}}}
@@ -30,4 +32,4 @@
 
   :global-vars {*warn-on-reflection* true}
 
-  :aliases      {"all" ["with-profile" "dev:dev,1.7:dev,master"]})
+  :aliases      {"all" ["with-profile" "dev:dev,1.7:dev,1.8:dev,1.9:dev,master"]})

--- a/project.clj
+++ b/project.clj
@@ -21,10 +21,10 @@
                           :codox {:sources ["src/clojure"]
                                   :output-dir "doc/api"}}}
 
-  :repositories {"sonatype"           {:url "http://oss.sonatype.org/content/repositories/releases"
+  :repositories {"sonatype"           {:url "https://oss.sonatype.org/content/repositories/releases"
                                        :snapshots false
                                        :releases {:checksum :fail :update :always}}
-                 "sonatype-snapshots" {:url "http://oss.sonatype.org/content/repositories/snapshots"
+                 "sonatype-snapshots" {:url "https://oss.sonatype.org/content/repositories/snapshots"
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
 

--- a/src/clojurewerkz/buffy/core.clj
+++ b/src/clojurewerkz/buffy/core.clj
@@ -58,11 +58,23 @@
   ([^long initial-capacity ^long max-capacity]
    (rewind-until-end (.directBuffer allocator initial-capacity max-capacity))))
 
-(defn wrapped-buffer
-  "Returns a buffer that wraps the given byte array, `j.nio.ByteBuffer` or netty `ByteBuf`"
-  [orig-buffer]
-  (rewind-until-end (.order (Unpooled/wrappedBuffer orig-buffer)
-                            (.order orig-buffer))))
+(defprotocol Wrappable
+  (wrapped-buffer [this] "Returns a buffer that wraps the given byte array, `j.nio.ByteBuffer` or netty `ByteBuf`"))
+
+(extend-protocol Wrappable
+  (Class/forName "[B")
+  (wrapped-buffer [this]
+    (rewind-until-end (Unpooled/wrappedBuffer ^bytes this)))
+
+  ByteBuffer
+  (wrapped-buffer [this]
+    (rewind-until-end (.order (Unpooled/wrappedBuffer this)
+                              (.order this))))
+
+  ByteBuf
+  (wrapped-buffer [this]
+    (rewind-until-end (.order (Unpooled/wrappedBuffer this)
+                              (.order this)))))
 
 (defprotocol Composable
   (decompose [this] [this buffer])

--- a/src/clojurewerkz/buffy/util.clj
+++ b/src/clojurewerkz/buffy/util.clj
@@ -13,16 +13,18 @@
 ;; limitations under the License.
 
 (ns clojurewerkz.buffy.util
-  (:refer-clojure :exclude [read])
-  (:require [clojurewerkz.buffy.types.protocols :refer :all])
+  (:refer-clojure :exclude [seqable?])
+  (:require [clojurewerkz.buffy.types.protocols :as p])
   (:import [io.netty.buffer ByteBuf ByteBufUtil]))
+
+(set! *warn-on-reflection* true)
 
 (defn positions
   "Returns a lazy sequence containing positions of elements"
   [types]
   ((fn rpositions [[t & more] current-pos]
      (when t
-       (cons current-pos (lazy-seq (rpositions more (+ current-pos (size t)))))))
+       (cons current-pos (lazy-seq (rpositions more (+ current-pos (p/size t)))))))
    types 0))
 
 (defn zero-fill-till-end
@@ -139,7 +141,7 @@
       (instance? clojure.lang.Seqable x)
       (nil? x)
       (instance? Iterable x)
-      (-> x .getClass .isArray)
+      (-> x class .isArray)
       (string? x)
       (instance? java.util.Map x)))
 


### PR DESCRIPTION
I've loved using Buffy, thanks for building it!

In the course of using Buffy and reading its source, I found a few minor issues:

* Test dependencies are included in the final artifact POM, requiring downstream `:exclusions`
* There were quite a few reflection warnings
* Leiningen complained about using `http` in repository URLs
* `FrameType`'s implementation had some methods from the `Frame` protocol within the `BuffyType` protocol implementation
* `wrapped-buffer` didn't function properly when given a byte array, and had some reflection warnings
* There was pervasive use of type accessors and protocol methods, which would be more readable and performant if the local type fields and protocol functions were used
* The use of `:refer :all` in requires made it difficult to read the source, since I couldn't tell where vars were coming from

This pull request addresses all of the above.